### PR TITLE
Synced README.md and help.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,47 @@
 # Stock Market Bot
-It is a bot to "play" with the stock market by using fake money! It also supports cryptocurrencies.
-The data is provided by [tradingview](https://www.tradingview.com) through the library [tradingview-scraper](https://github.com/imxeno/tradingview-scraper).
+
+It is a bot to "play" with the stock market by using fake money! It trades all tickers from TradingView.
+The data is provided by [TradingView](https://www.tradingview.com) through the library [tradingview-scraper](https://github.com/imxeno/tradingview-scraper).
 
 ## Available commands
-Prefix by default: `sm!`
+
+Prefix by default: `sm!`.
+
 ### Basics
-- `help` Shows the help menu which is this message.
-- `init <amount>` Opens your account.
-(You can specify how much money to start with; Defaults to 100000.)
-- `del` Delete your account from the database. (This action cannot be reversed.)
-- `prefix <prefix>` Change the prefix of the bot.
-- `ping` To see the latency between you, the bot, and the API.
-- `about` Statistics about the bot.
+
+- `help` - Shows the help menu, which is this message.
+- `init <amount>` - Opens your account.
+(You can specify how much money to start with; 0 < `<amount>` =< 100000, default is 100000.)
+- `del` - Delete your account from the database. (This action cannot be reversed.)
+- `prefix <prefix>` - Change the prefix of the bot. Can be done anytime and an endless amount of times.
+- `ping` - To see the latency between you, the bot, and the API.
+- `about` - Statistics about the bot.
+- `help <command>` - Help and aliases for specified command.
 
 ### Account Info
-- `balance` or `balance @User` To admire your / user's wealth.
-- `list` or `list @User` Your / user's open positions.
-- `daily` To get your daily reward.
-- `vote` Vote for the bot and get a reward.
-- `leaderboard` Who is the richest in your server? (Not working)
+
+- `balance`/`balance @User` - To admire your/user's wealth.
+- `list`/`list @User` - Your/user's open positions.
+- `daily` - To get your daily reward.
+- `vote` - Vote for the bot and get a reward.
+- `leaderboard` - Who is the richest in your server? (Not working)
 
 ### Trading
-- `search` Search for tickers and markets that are tradable with the bot.
-- `show <stock>` Get info about a ticker. (ex: sm!show AAPL)
-- `newtrade <buy/sell> <ticker> <price/shares>` Buy/sell tickers.
+
+- `search` - Search for tickers that can be traded with the bot.
+- `show <stock>` - Get info about a ticker. (ex: sm!show AAPL)
+- `newtrade <buy/sell> <ticker> <price/share>` - Buy/sell tickers.
 (eg: `sm!newtrade buy AAPL 100 share` will buy 100 shares of Apple, `sm!newtrade buy AAPL 100` will buy 100 dollars worth of Apple shares.)
-(When selling / shorting, you gain money as the asset depreciates.)
-- `closetrade <ID>` Closes a trade. The ID can be found with the list command. (ex: sm!ct 0)
+(When shorting, you gain money as the asset depreciates.)
+- `closetrade <ID>` - Closes a trade. The ID can be found in your list. (ex: sm!closetrade 0)
 
-### Available aliases
-`help <command>` for aliases for that command.
+## Okay, how do I play?
 
-### Okay, how do I play?
-First, you are going to look for a market. Type `sm!search`, it will redirect you to a website.
-Then type `sm!show <symbol>` if you want more details about it.
-Now it's time to trade! Follow the instructions above for `newtrade` and `closetrade`!
-Happy trading!
+First, create your account with the bot with `<prefix>init <amount>`. Then, search for a ticker with `<prefix>show <ticker>`, and decide if you want to open a position. Finally, make that trade when desired with `<prefix>newtrade <buy/sell> <ticker> <price/share>`. Finally, manage your account with `<prefix>list` and `<prefix>closetrade <ID>`. You can search for tickers with `<prefix>search`.
 
-### Can I run this code on my bot?
-- Yup! Please fill the missing fields in `config/blank.env` and rename it to `config/prod.env`. (Free MySQL databases can be found on https://www.alwaysdata.com)
-- `npm`, `yarn` and `nodejs` latest versions should be installed.
+## Can I run this code on my bot?
+
+- Yup! Please fill the missing fields in `config/blank.env` and rename it to `config/prod.env`. (Free MySQL databases can be found on <https://www.alwaysdata.com>)
+- `npm`, `yarn`, and `nodejs` latest versions should be installed.
 - Run `yarn install` in the root directory to install the necessary modules.
-- Run `./js/app.js`
+- Run `./js/app.js`.

--- a/js/commands/help.js
+++ b/js/commands/help.js
@@ -27,35 +27,32 @@ exports.run = (client, msg, args) => {
 		[
 			{
 				name: 'Basics',
-				value: "- `help` Shows the help menu which is this message.\n"
+				value: "- `help` - Shows the help menu which is this message.\n"
 					+ '- `init <amount>` Opens your account.\n'
-					+ '*(You can specify how much money to start with; Defaults to 100000.)*\n'
-					+ '- `del` Delete your account from the database. (__This action cannot be reversed.__)\n'
-					+ '- `prefix <prefix>` Change the prefix of the bot.\n'
-					+ '- `ping` To see the latency between you, the bot, and the API.\n'
-					+ '- `about` Statistics about the bot.\n',
+					+ '*(You can specify how much money to start with; 0 < `<amount>` =< 100000.)*\n'
+					+ '- `del` - Delete your account from the database. (__This action cannot be reversed.__)\n'
+					+ '- `prefix <prefix>` - Change the prefix of the bot. Can be done anytime and an endless amount of times.\n'
+					+ '- `ping` - To see the latency between you, the bot, and the API.\n'
+					+ '- `about` - Statistics about the bot.\n'
+					+ '- `help <command>` - Help and aliases for specified command.\n',
 			},
 			{
 				name: 'Account Info',
-				value: "- `balance` or `balance @User` To admire your / user's wealth.\n"
-					+ "- `list` / `list @User` Your / user's open positions.\n"
-					+ '- `daily` To get your daily reward.\n'
-					+ '- `vote` Vote for the bot and get a reward.\n'
-					+ '- `leaderboard` Who is the richest in your server? (Not working)\n',
+				value: "- `balance`/`balance @User` - To admire your/user's wealth.\n"
+					+ "- `list`/`list @User` - Your/user's open positions.\n"
+					+ '- `daily` - To get your daily reward.\n'
+					+ '- `vote` - Vote for the bot and get a reward.\n'
+					+ '- `leaderboard` - Who is the richest in your server? (Not working)\n',
 			},
 			{
 				name: 'Trading',
-				value: '- `search` Search for tickers and markets that are tradable with the bot.\n'
-					+ '- `show <stock>` Get info about a ticker. (ex: `sm!show AAPL`)\n'
-					+ '- `newtrade <buy/short> <ticker> <price/shares>` Buy/short tickers.\n'
+				value: '- `search` - Search for tickers and markets that can be traded with the bot on TradingView.\n'
+					+ '- `show <stock>` - Get info about a ticker. (ex: `sm!show AAPL`)\n'
+					+ '- `newtrade <buy/short> <ticker> <price/share>` - Buy/short tickers.\n'
 					+ '*(ex: `sm!newtrade buy AAPL 100 share` will buy 100 shares of Apple, `sm!newtrade buy AAPL 100` will buy 100 dollars worth of Apple shares.)*\n'
 					+ '*(When shorting, you gain money as the asset depreciates.)*\n'
-					+ '- `closetrade <ID>` Closes a trade. The ID can be found with the `list` command. (ex: `sm!ct 0`)\n',
+					+ '- `closetrade <ID>` - Closes a trade. The ID can be found in your list. (ex: `sm!ct 0`)\n',
 
-			},
-			{
-				name: '*Available aliases*',
-				value: 'Type `help <command>` for aliases for that command.\n',
 			},
 			{
 				name: 'Support',


### PR DESCRIPTION
I was not stupid and copied the code. I adhered to the syntax of the file's respective language. I moved the help command from Available aliases to Basics as it was kind of weird seeing it alone. Hopefully, I did it right in help.js, please check my work there. I also added -s in between the command and the explanation. Hopefully, it does not interfere with those `-`s. The structure of the headers in `README.md` was also changed to fit the hierarchy. I know this help menu and readme stuff can get pretty annoying to oversee but I would expect a couple more in the future. To be honest, there is not a lot of functionality that the bot does not have except for maybe a market open/close reminder. I will look into that, possibly suggest a solution. and get rid of the existing external one from @sheeblou. By the way, this pull request was done from Gh command line, it is my first one. I had to go to documentation on how to. Oh, I might have screwed up my computer as I experimentally typed `npm i` in the terminal for the repo folder and a bunch of packages installed. Then, an error came and uninstalling brought back those errors. Will delete those packages from my File Explorer once I find them. Good luck. 